### PR TITLE
Remove reference to an "operator backend client"

### DIFF
--- a/Integration-guides/PAF-Integration-Guide.md
+++ b/Integration-guides/PAF-Integration-Guide.md
@@ -31,7 +31,7 @@ The PAF client node is currently hosted by Criteo, but could be hosted by someon
         
         -   ⚠️ the TLD+1 must be the same as the Website (ex: `www.example-website.com` and `some-sub-site.example-website.com` must use a PAF with domain `.example-website.com`)
             
- **Configure** this new client. For example, using [the NodeJS implementation](https://github.com/prebid/paf-mvp-implementation/tree/main/paf-mvp-operator-client-express "https://github.com/prebid/paf-mvp-implementation/tree/main/paf-mvp-operator-client-express"):
+ **Configure** this new client. For example, using [the NodeJS implementation](https://github.com/prebid/paf-mvp-implementation/tree/main/paf-mvp-client-express "https://github.com/prebid/paf-mvp-implementation/tree/main/paf-mvp-client-express"):
 ```javascript
        // This is just an example of a basic client node configuration
     addClientNodeEndpoints(

--- a/Integration-guides/PAF-Integration-Guide.md
+++ b/Integration-guides/PAF-Integration-Guide.md
@@ -19,12 +19,12 @@ In order to use the OneKey protocols, a Website needs:
 ## Roles
 
 
-| **Role<br>**    	| **Description<br>**                                                                                                                                                                                                                                       	|
-|-----------------	|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|
-| Website Owner   	| Self explanatory                                                                                                                                                                                                                                          	|
-| CMP             	| Consent Management Platform<br>Provides the UX to let users express their data processing preferences<br>Example partners: Sourcepoint, OneTrust, Quantcast …                                                                                             	|
-| Client Node 	| Provides key functions for the Website Owners:<br>Key Management and Identity Endpoint<br>Sign communications with the Operator (acts as an operator proxy)<br>Generate Seeds to initiate Transactions<br>Collate the Audit Log for each Ads  	|
-| Operator    	| Manages the storage and synchronization of ids and Preferences across the OneKey network.    
+| **Role<br>**    	 | **Description<br>**                                                                                                                                                                                                                                       	 |
+|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Website Owner   	 | Self explanatory                                                                                                                                                                                                                                          	 |
+| CMP             	 | Consent Management Platform<br>Provides the UX to let users express their data processing preferences<br>Example partners: Sourcepoint, OneTrust, Quantcast …                                                                                             	 |
+| Client Node 	     | Provides key functions for the Website Owners:<br>Key Management and Identity Endpoint<br>Sign communications with the Operator (acts as an operator proxy)<br>Generate Seeds to initiate Transactions<br>Collate the Audit Log for each Ads  	             |
+| Operator    	     | Manages the storage and synchronization of ids and Preferences across the OneKey network.                                                                                                                                                                   |
 
 The Website Owner and Operator roles need to be filled by separate entities.
 

--- a/mvp-spec/README.md
+++ b/mvp-spec/README.md
@@ -65,7 +65,7 @@ The User Id and Preferences management involves:
 - The Operator
 - The advertiser or publisher web site
 
-See [workflows](workflows.md), [operator-api.md](operator-api.md), and [paf-client-node.md](paf-client-node.md). 
+See [workflows](workflows.md), [operator-api.md](operator-api.md), and [client-node.md](client-node.md). 
 
 ### Ad auction
 
@@ -100,7 +100,7 @@ See [audit-log-design.md](audit-log-design.md) and [audit-log-requirements.md](a
 | [operator-design.md](operator-design.md)                                                            | Design of the generation of PAF Data.                                                               |
 | [operator-design-alternative-swan.md](../alternative%20designs/operator-design-alternative-swan.md) | Summary of the SWAN solution for generating PAF Data.                                               |
 | [operator-requirements.md](operator-requirements.md)                                                | Requirements for the generation of the PAF Data.                                                    |
-| [paf-client-node.md](paf-client-node.md)                                                            | Website integration: frontend library, PAF client node, operator backend                            |
+| [client-node.md](client-node.md)                                                                    | Website integration: frontend library, PAF client node, operator backend                            |
 | [Integration Guide.md](../Integration-guides/PAF-Integration-Guide.md)                              | Guide to integrate into current PAF MVP                                                             |
 | [model/](model)                                                                                     | Data and messages model                                                                             |
 | [json-schemas/](json-schemas)                                                                       | Data and messages model in [JSON schema](https://json-schema.org/understanding-json-schema/) format |

--- a/mvp-spec/client-node.md
+++ b/mvp-spec/client-node.md
@@ -1,29 +1,29 @@
-# PAF client node
+# Client node
 
 ⚠️ TO BE UPDATED: missing documentation about **signing seeds**.
 
-## Interacting with the operator: frontend, client node and backend
+## Interacting with the operator: frontend, client node
 
-**Websites** that need to get access to PAF data:
+**Websites** that need to get access to data:
 
 - read user ids and preferences
 - write user preferences
 - or both
 
-Ids and preferences are stored as **1st party cookies on the PAF top level +1 domain** (aka TLD+1).
+Ids and preferences are stored as **1st party cookies on the OneKey top level +1 domain** (aka TLD+1).
 
 As a reminder, the content of these websites
 is _served by a http server_ and it can then use Javascript _in the browser_.
 
-- PAF provides a "**frontend library**" to call the operator on REST or "redirect" endpoints (see [operator-api.md](operator-api.md) for details).
+- OneKey provides a "**frontend library**" to call the operator on REST or "redirect" endpoints (see [operator-api.md](operator-api.md) for details).
     - But only **signed** requests can be sent to the operator and these requests are signed using a **private key**,
       which must never be sent to the browser.
 
-- Thus, PAF also provides a "**PAF client node**" backend component which the frontend library uses to sign the requests on
+- Thus, OneKey also provides a "**client node**" component which the frontend library uses to sign the requests on
   its behalf.
     - this node can be hosted by the website's owner or by a tech vendor
 
-- Note: clients of the PAF operators _can_ decide to use an operator client that is part of their website's HTTP server
+- Note: clients of the operators _can_ decide to use an operator client that is part of their website's HTTP server
   and intercepts all requests made to display the web pages to trigger **HTTP** redirects (not Javascript).
   - This special kind of integration (a "**backend operator client**") is not detailed here but can be investigated further if needed.
 
@@ -40,25 +40,21 @@ flowchart LR
             frontend -->|get signed requests| proxy
             frontend -->|generate seed| proxy
             
-            proxy("PAF client node")
+            proxy("Client node")
             proxy -.->|sign requests, sign seeds| proxy
-            
-            backend("backend operator client<br>(optional)")
-            backend -.->|sign requests| backend
            
         end
     end
     
-    backend --->|send signed requests| O
     frontend --->|"send signed requests"| O
     
-    O("(backend) PAF Operator")
+    O("(backend) Operator")
     click O href "operator-api.md" "Operator API"
 ```
 
-## PAF client node
+## Client node
 
-The **PAF client node** is an API called by the frontend library to sign and verify requests sent and received to / from the
+The **client node** is an API called by the frontend library to sign and verify requests sent and received to / from the
 operator.
 
 It acts as a proxy that transforms unsigned requests into signed ones.
@@ -77,9 +73,9 @@ To do so, it exposes:
 | Write ids & prefs         | Redirect to [write](operator-api.md#write-ids-&-preferences) operator endpoint                         | Signed "write" request<br>(see [operator API](operator-api.md#write-ids-&-preferences))    | redirect to operator                                             | `POST /paf-proxy/v1/ids-prefs`  | `GET /paf-proxy/v1/redirect/post-ids-prefs` |
 | **Verify** read           | Verify the response received from the operator                                                         | Signed "read" **response**<br>(see [operator API](operator-api.md#read-ids-&-preferences)) | Same as input if verification succeeded, error message otherwise | `POST /paf-proxy/verify/read`   | N/A                                         |
 
-ℹ️ An example implementation (for NodeJS) of a PAF client node is available in [the implementation project](https://github.com/criteo/paf-mvp-implementation/tree/main/paf-mvp-client-express)
+ℹ️ An example implementation (for NodeJS) of a client node is available in [the implementation project](https://github.com/criteo/paf-mvp-implementation/tree/main/paf-mvp-client-express)
 
-⚠️ Note that in the following examples, the PAF client node is supposed to be hosted on the `cmp.com` domain.
+⚠️ Note that in the following examples, the client node is supposed to be hosted on the `cmp.com` domain.
 
 ### Read ids & preferences
 
@@ -420,20 +416,20 @@ Host: cmp.com
 
 ## Frontend library
 
-The "frontend library" is implemented via a Javascript script provided by PAF and available on [the implementation project](https://github.com/criteo/paf-mvp-implementation/tree/main/paf-mvp-frontend).
+The "frontend library" is implemented via a Javascript script provided by OneKey and available on [the implementation project](https://github.com/criteo/paf-mvp-implementation/tree/main/paf-mvp-frontend).
 
-This library is a static file that can be added to any website, but requires **the host name of the PAF client node** as configuration input.
+This library is a static file that can be added to any website, but requires **the host name of the client node** as configuration input.
 
 ## Implementation details
 
 <details>
 <summary>Read ids and preferences</summary>
 
-The following diagram details the steps needed to read existing cookies from PAF
+The following diagram details the steps needed to read existing cookies from OneKey
 
 - at browser level the **frontend operator client** (a Javascript library) is used
     - depending on the context, the JS library calls a REST or "redirect" endpoint on the operator
-    - it relies on the **PAF client node**, a component responsible for building operator URLs to call.
+    - it relies on the **client node**, a component responsible for building operator URLs to call.
 
 ### Test support of 3rd party cookies
 
@@ -469,7 +465,7 @@ flowchart TD
         
     end
     
-    subgraph "PAF client node"
+    subgraph "client node"
         ClientJsRedirect[redirect read]
         ClientCallJson["read"]
         ClientCallTest3PC["test3PC"]

--- a/mvp-spec/operator-api.md
+++ b/mvp-spec/operator-api.md
@@ -784,7 +784,7 @@ the operator attempts to write a short-life `paf_test_3pc` cookie.
 This endpoint is **only** called immediately after a call to `GET /paf/v1/ids-prefs` has failed, to
 check if the `paf_test_3pc` cookie was indeed written by the web browser.
 
-See [implementation details](./paf-client-node.md#implementation-details) for details.
+See [implementation details](./client-node.md#implementation-details) for details.
 
 #### REST verify 3PC: `GET /paf/v1/3pc`
 

--- a/mvp-spec/operator-requirements.md
+++ b/mvp-spec/operator-requirements.md
@@ -26,9 +26,6 @@ We represent:
 - two typical workflows
   - the first interaction with Prebid where a user visits a publisher's page, that triggers a CMP
   - a visit to an advertiser while the user already opted in to Prebid
-- with different configurations
-  - the publisher doesn't use an operator **backend** client: redirects, when needed, are triggered in Javascript
-  - the advertiser uses an operator backend client: when needed, redirects can be triggered via an HTTP response
 - in two different contexts
   - where the browser supports third party cookies (3PC)
   - where it doesn't

--- a/mvp-spec/paf-client-node.md
+++ b/mvp-spec/paf-client-node.md
@@ -23,9 +23,9 @@ is _served by a http server_ and it can then use Javascript _in the browser_.
   its behalf.
     - this node can be hosted by the website's owner or by a tech vendor
 
-- Finally, clients of the PAF operators can use an optional "**backend operator client**" that will trigger HTTP redirects upfront, before it would be done in JS via the frontend library. 
-    - this is part of the website's http server
-    - this can be interesting to trigger HTTP redirects before any web page is served
+- Note: clients of the PAF operators _can_ decide to use an operator client that is part of their website's HTTP server
+  and intercepts all requests made to display the web pages to trigger **HTTP** redirects (not Javascript).
+  - This special kind of integration (a "**backend operator client**") is not detailed here but can be investigated further if needed.
 
 ```mermaid
 flowchart LR
@@ -77,7 +77,7 @@ To do so, it exposes:
 | Write ids & prefs         | Redirect to [write](operator-api.md#write-ids-&-preferences) operator endpoint                         | Signed "write" request<br>(see [operator API](operator-api.md#write-ids-&-preferences))    | redirect to operator                                             | `POST /paf-proxy/v1/ids-prefs`  | `GET /paf-proxy/v1/redirect/post-ids-prefs` |
 | **Verify** read           | Verify the response received from the operator                                                         | Signed "read" **response**<br>(see [operator API](operator-api.md#read-ids-&-preferences)) | Same as input if verification succeeded, error message otherwise | `POST /paf-proxy/verify/read`   | N/A                                         |
 
-ℹ️ An example implementation (for NodeJS) of a PAF client node is available in [the implementation project](https://github.com/criteo/paf-mvp-implementation/tree/main/paf-mvp-operator-client-express)
+ℹ️ An example implementation (for NodeJS) of a PAF client node is available in [the implementation project](https://github.com/criteo/paf-mvp-implementation/tree/main/paf-mvp-client-express)
 
 ⚠️ Note that in the following examples, the PAF client node is supposed to be hosted on the `cmp.com` domain.
 
@@ -424,13 +424,6 @@ The "frontend library" is implemented via a Javascript script provided by PAF an
 
 This library is a static file that can be added to any website, but requires **the host name of the PAF client node** as configuration input.
 
-## Backend operator client
-
-The backend operator client is an **optional** component that website owners can use if they want to trigger redirect
-at the HTTP level rather than via Javascript, in case the browser doesn't support 3PC.
-
-ℹ️ An example implementation (for NodeJS) of a backend operator client is available in [the implementation project](https://github.com/criteo/paf-mvp-implementation/tree/main/paf-mvp-operator-client-express).
-
 ## Implementation details
 
 <details>
@@ -438,8 +431,6 @@ at the HTTP level rather than via Javascript, in case the browser doesn't suppor
 
 The following diagram details the steps needed to read existing cookies from PAF
 
-- at server level, _if the website decides to use a **backend operator client**_, HTTP redirects can be triggered when
-  needed
 - at browser level the **frontend operator client** (a Javascript library) is used
     - depending on the context, the JS library calls a REST or "redirect" endpoint on the operator
     - it relies on the **PAF client node**, a component responsible for building operator URLs to call.
@@ -448,9 +439,6 @@ The following diagram details the steps needed to read existing cookies from PAF
 
 To test if third party cookies are supported and trigger redirect otherwise, the following logic is used:
 
-1. if a backend client is used, then
-    - based on user agent, if the browser is known to **not** support 3PC (ex: Safari) ➡️ consider no 3PC and
-      immediately **HTTP redirect**
 2. in Javascript,
     - based on user agent, if the browser is known to **not** support 3PC (ex: Safari) ➡️ consider no 3PC and
       immediately **javascript redirect**
@@ -462,54 +450,9 @@ To test if third party cookies are supported and trigger redirect otherwise, the
     - if success ➡️ 3PC **are** supported, it's just that the user is not known
     - if failure ➡️ 3PC are **not** supported, **javascript redirect**
 
-### Actual cookies writing
-
-Note: cookies set by Javascript can be read by the http server when it receives a successive call, and vice-versa.
-
-In other words, after a redirect by the operator back to the website,
-
-- when using a **backend operator client**:
-    - the backend operator client will set 1st party cookies (either a value or "unknown")
-    - these cookies will be visible by the JS
-    - so in the JS part of the diagram below, the answer to the question "Any Prebid 1st party 🍪?" is: **yes** and the
-      cookies won't be written twice
-- when not using a backend operator client, these cookies will be written by JS
-
 ```mermaid
 flowchart TD
-    subgraph noMiddleware [HTTP server without backend operator client]
-        NoMiddlewareServe[serve HTML page]
-    end
-    
-    subgraph middleware[HTTP server with backend operator client]
-        MiddlewareCookies{"Any Prebid 1st party 🍪?"}
-        MiddlewareAfterRedirect{Redirected from operator?}
-        MiddlewareNonEmptyData{Received data?}
-        MiddlewareVerifyRead["verify signature"]
-        Middleware3PC{Browser known to support 3PC?}
-        MiddlewareServe[serve HTML page]
-        MiddlewareRedirect[HTTP redirect]
-        MiddlewareSave["Set 1st party Prebid 🍪 = data"]
-        style MiddlewareSave stroke:red,stroke-width:4px
-        MiddlewareSaveNothing["Set 1st party Prebid 🍪 = 'unknown'"]
-        style MiddlewareSaveNothing stroke:red,stroke-width:4px
-        
-        Middleware3PC -->|No| MiddlewareRedirect
-        Middleware3PC -->|Yes| MiddlewareServe
-        
-        MiddlewareCookies -->|No| MiddlewareAfterRedirect
-        
-        MiddlewareAfterRedirect -->|No| Middleware3PC
-        MiddlewareAfterRedirect -->|Yes| MiddlewareNonEmptyData
-        
-        MiddlewareNonEmptyData -->|No| MiddlewareSaveNothing --> MiddlewareServe
-        MiddlewareNonEmptyData -->|Yes| MiddlewareVerifyRead
-        MiddlewareVerifyRead --> MiddlewareSave --> MiddlewareServe
-        
-        MiddlewareCookies -->|Yes| MiddlewareServe
-    end
-
-    subgraph "HTML page (with frontend operator client JS library)"
+    subgraph "HTML page (with frontend JS library)"
         HtmlLoad[Page load]
         HtmlAfterRedirect{Redirected from operator?}
         HtmlCookies{"Any Prebid 1st party 🍪?"}
@@ -539,16 +482,9 @@ flowchart TD
         OperatorVerify3PC["json/verify3PC endpoint"]
     end
     
-    User[User visit] -------> Get
+    User[User visit] -------> HtmlLoad
     style User stroke:#333,stroke-width:4px
     
-    Get[GET web page]
-    Get --> noMiddleware
-    Get --> middleware
-    
-    MiddlewareServe --> HtmlLoad
-    MiddlewareRedirect -- HTTP 303 operator/redirect/read --> OperatorRedirect
-    NoMiddlewareServe ------> HtmlLoad
     HtmlLoad --> HtmlCookies
     
     HtmlAnyData -->|No| HtmlSaveNothing --> HtmlDone  


### PR DESCRIPTION
- it was creating confusion and did not get real attraction
- its implementation has been deprecated
- can be investigated again if needed